### PR TITLE
fix all blind texts being dark

### DIFF
--- a/Tetrapak.lua
+++ b/Tetrapak.lua
@@ -231,9 +231,9 @@ end
     end
 
     local loc_colour_ref = loc_colour
-    function loc_colour(key)
+    function loc_colour(key, _default)
         if key == CURSERARITY then return HEX("444444")
-        else return loc_colour_ref(key) end
+        else return loc_colour_ref(key, _default) end
     end
 
 


### PR DESCRIPTION
## Problem

The `loc_colour` override only accepts a single parameter (`key`), but the vanilla function signature is `loc_colour(_c, _default)`. When the override forwards to the original function via `loc_colour_ref(key)`, the `_default` parameter is silently dropped.

The localization text parser calls `loc_colour(nil, args.default_col)` for text segments without an explicit color code. Without the default being forwarded, the vanilla function falls through to `G.C.UI.TEXT_DARK` (`#4F6367`) instead of the caller's intended default color.

This causes any localized text relying on the default color to render as dark gray instead of the expected color. Most visibly, blind description text, making it unreadable against the dark background.

## Fix

Forward the `_default` parameter through the override to `loc_colour_ref`.